### PR TITLE
Passing in parent model when proxying event

### DIFF
--- a/backbone-associations.js
+++ b/backbone-associations.js
@@ -109,7 +109,10 @@
                         }
                         //Add proxy events to respective parents
                         this.attributes[relationKey].off("all");
-                        this.attributes[relationKey].on("all",function(){return this.trigger.apply(this,arguments);},this);
+                        this.attributes[relationKey].on("all",function(){
+                           arguments[1] = this;
+                           return this.trigger.apply(this,arguments);
+                        },this);
                         //If reference has changed, trigger `change:attribute` event
                         refChanged && this.trigger('change:'+relationKey,this,this.get(relationKey),relationOptions);
                         //Create a local `processedRelations` array to store the relation key which has been processed.

--- a/backbone-associations.js
+++ b/backbone-associations.js
@@ -1,5 +1,5 @@
 //
-// Backbone-associations.js 0.1.0
+// Backbone-associations.js 0.2.1
 //
 // (c) 2012 Dhruva Ray, Jaynti Kanani
 //


### PR DESCRIPTION
Instead of blindly proxying the event, we set the model to the parent.
This way listeners that are expecting that "brand" of model in the callback,
will get the correct one.

I ran in to this while using a certain plugin which maintains "live" subcollections. It was filtering on the 'change' event, but passing in the model in the callback to the filter. Since the model was not correct (it was the child, not the parent), the filtering was failing.
