### PR TITLE
reverse option

### DIFF
--- a/backbone-associations.js
+++ b/backbone-associations.js
@@ -58,6 +58,7 @@
                 //Iterate over `this.relations` and `set` model and collection values
                 _.each(this.relations ,function(relation){
                     var relationKey = relation.key, relatedModel = relation.relatedModel, collectiontype = relation.collectionType;
+                    var reverse = relation.reverse || false;
                     if (attributes[relationKey] != undefined ){
                         //Get value of attribute with relation key in `val`
                         var val = getValue(attributes,relationKey);
@@ -107,6 +108,9 @@
                             //Set `val` to model with options
                             this.attributes[relationKey].set(val,relationOptions);
                         }
+                        if (reverse) {
+                            this.attributes[relationKey].reverse = _.clone(this);
+                        }  
                         //Add proxy events to respective parents
                         this.attributes[relationKey].off("all");
                         this.attributes[relationKey].on("all",function(){return this.trigger.apply(this,arguments);},this);


### PR DESCRIPTION
Issue #10

May be it will be useful for somebody.
Now we can automatically create association models(collections) with reference to parent like this

``` javascript
TuneModel = Backbone.AssociatedModel.extend();

UserModel = Backbone.AssociatedModel.extend({
    defaults: {
        tunes: [],
        name: "username"
    },
    relations: [
      {
        type: Backbone.Many,
        key: "tunes",
        relatedModel: TuneModel,
        // collectionType: TuneCollection,
        reverse: true
      },
        {
        type: Backbone.One,
        key: "tune_one",
        relatedModel: TuneModel,
        reverse: true
      }
    ]
  });

user = new UserModel();
user.get("tunes").add({
    title: "title",
    artist: "artist"
});

user.set("tune_one",{
    title: "title",
    artist: "artist"
});
console.log(user)​
```

http://jsfiddle.net/sergkusch/em26w/3/
