### PR TITLE
Keep triggered events in a hash rather than using a flag

### DIFF
--- a/backbone-associations.js
+++ b/backbone-associations.js
@@ -35,6 +35,8 @@
     Backbone.AssociatedModel = Backbone.Model.extend({
         //Define relations with Associated Model
         relations: undefined,
+        //Define a hash to keep current triggered events
+        triggedEvents: {},
         //Set a hash of model attributes on the object,
         //firing `"change"` unless you choose to silence it.
         //It maintains relations between models during the set operation. It also bubbles up child events to the parent.
@@ -155,12 +157,13 @@
         // `trigger` the event for `Associated Model`
         trigger : function(){
             //Check & Add `visited` tag to prevent event of cycle
-            if(!this.visitedTrigger){
+            var events = arguments[0];
+            if(!this.triggedEvents[events]){
                 // mark as `visited`
-                this.visitedTrigger = true;
+                this.triggedEvents[events] = true;
                 Backbone.Model.prototype.trigger.apply(this,arguments);
                 //delete `visited` tag to allow trigger for next `set` operation
-                delete this.visitedTrigger;
+                delete this.triggedEvents[events];
             }
             return this;
         },


### PR DESCRIPTION
I think we should keep the triggered events in a hash rather than using a global flag (for all events). This can lead to some events never been triggered when some other events are being triggered.
