### PR TITLE
Fixing browser-side error 'module is not defined'

### DIFF
--- a/backbone-associations.js
+++ b/backbone-associations.js
@@ -24,7 +24,9 @@
     if (typeof require !== 'undefined') {
         _ = require('underscore');
         Backbone = require('backbone');
-        exports = module.exports = Backbone;
+        if(typeof exports !== 'undefined') {
+            exports = module.exports = Backbone;   
+        }
     } else {
         _ = root._;
         Backbone = root.Backbone;


### PR DESCRIPTION
exports / module.exports are undefined browser-side (as suggested in the comment on line 15) is used only server-side, 
so it breaks browser-side implementations to assign them without checking if they exist first.
