### PR TITLE
Using `Backbone.Collection#set` to avoid losing reference to existing nested collections.

### DIFF
--- a/backbone-associations.js
+++ b/backbone-associations.js
@@ -135,10 +135,16 @@
 
                             if (val instanceof BackboneCollection) {
                                 data = val;
+
+                                if (currentCollection) {
+                                  data = currentCollection
+                                  currentCollection.set(val.toJSON(), relationOptions);
+                                }
+
                                 attributes[relationKey] = data;
                             } else if (currentCollection) {
                                 data = currentCollection;
-                                currentCollection.set(attributes[relationKey], relationOptions);
+                                currentCollection.set(val, relationOptions);
                                 attributes[relationKey] = data;
                             } else {
                                 data = collectionType ? new collectionType() : this._createCollection(relatedModel);

--- a/backbone-associations.js
+++ b/backbone-associations.js
@@ -116,7 +116,7 @@
                 _.each(this.relations, function (relation) {
                     var relationKey = relation.key, relatedModel = relation.relatedModel,
                         collectionType = relation.collectionType,
-                        val, relationOptions, data, relationValue;
+                        val, relationOptions, data, relationValue, currentCollection = this.get(relationKey);
                     if (attributes[relationKey]) {
                         //Get value of attribute with relation key in `val`.
                         val = _.result(attributes, relationKey);
@@ -135,6 +135,10 @@
 
                             if (val instanceof BackboneCollection) {
                                 data = val;
+                                attributes[relationKey] = data;
+                            } else if (currentCollection) {
+                                data = currentCollection;
+                                currentCollection.set(attributes[relationKey], relationOptions);
                                 attributes[relationKey] = data;
                             } else {
                                 data = collectionType ? new collectionType() : this._createCollection(relatedModel);

--- a/test/associated-model.js
+++ b/test/associated-model.js
@@ -277,6 +277,18 @@ $(document).ready(function () {
         ok(true);
     });
 
+    test("set nested collections when there is existing collections", 3, function () {
+      var originalCollection  = emp.get('dependents')
+
+      child1.on('remove', function () { ok(true) })
+      child2.on('add', function () { ok(true); })
+      parent1.on('add', function () { ok(false); }) // parent shouldn't be added or remove
+      parent1.on('remove', function () { ok(false); })
+
+      emp.set({"dependents":[child2, parent1]});
+      equal(originalCollection, emp.get('dependents'), "original collection has been changed, but it shouldn't")
+    })
+
     test("function can also be passed as value of attribute on set", 2, function () {
         var dept2 = function () {
             return {


### PR DESCRIPTION
Backbone 1.0 introduced the method `Backbone.Collection#set` that will add/remove/merge collection models as needed. This works better than reseting the collection by always creating a new one.

When setting raw attributes on a model with a nested collection you can use this so that you don't lose references on nested models and collections.
