### PR TITLE
Backbone.Association.deepAttributes

### DIFF
--- a/backbone-associations.js
+++ b/backbone-associations.js
@@ -43,7 +43,27 @@
         "sync", "error", "sort", "request"];
 
     Backbone.Associations = {
-        VERSION:"0.4.2"
+        VERSION:"0.4.2",
+        deepAttributes: function(obj) {
+            var recurse = Backbone.Associations.deepAttributes;
+            if (obj instanceof BackboneModel) {
+                return recurse(obj.attributes);
+            } else if (obj instanceof BackboneCollection) {
+                return obj.map(recurse);
+            } else if (_.isArray(obj)) {
+                return _.map(obj, recurse);
+            } else if (_.isObject(obj)) {
+                var attributes = {};
+                for (var prop in obj) {
+                    if(obj.hasOwnProperty(prop)) {
+                        attributes[prop] = recurse(obj[prop]);
+                    }
+                }
+                return attributes;
+            } else {
+                return obj;
+            }
+        }
     };
 
     // Backbone.AssociatedModel

--- a/test/associated-model.js
+++ b/test/associated-model.js
@@ -1562,6 +1562,10 @@ $(document).ready(function () {
         }
     });
 
+    test("VERSION", 1, function() {
+        ok(Backbone.Associations.VERSION, "Backbone.Associations.VERSION exists");
+    });
+
     test("deepAttributes", 7, function() {
         var deepAttributes = Backbone.Associations.deepAttributes;
         var empAttributes = {

--- a/test/associated-model.js
+++ b/test/associated-model.js
@@ -1535,6 +1535,75 @@ $(document).ready(function () {
         equal(cloneNode.get('parent').get('name'), 'clone-n2', "name of node1's parent should be `clone-n2`");
     });
 
+    module("Backbone.Associations", {
+        setup: function() {
+            emp = new Employee({
+                fname:"John",
+                lname:"Smith",
+                age:21,
+                sex:"M"
+            });
+
+            child1 = new Dependent({
+                fname:"Jane",
+                lname:"Smith",
+                sex:"F",
+                relationship:"C"
+            });
+
+            child2 = new Dependent({
+                fname:"Barbara",
+                lname:"Ruth",
+                sex:"F",
+                relationship:"C"
+            });
+
+            emp.set({"dependents":[child1, child2]});
+        }
+    });
+
+    test("deepAttributes", 7, function() {
+        var deepAttributes = Backbone.Associations.deepAttributes;
+        var empAttributes = {
+          "age": 21,
+          "dependents": [
+            {
+              "age": 0,
+              "fname": "Jane",
+              "lname": "Smith",
+              "relationship": "C",
+              "sex": "F"
+            },
+            {
+              "age": 0,
+              "fname": "Barbara",
+              "lname": "Ruth",
+              "relationship": "C",
+              "sex": "F"
+            }
+          ],
+          "fname": "John",
+          "lname": "Smith",
+          "manager": null,
+          "sex": "M",
+          "works_for": {
+            "controls": [],
+            "locations": [],
+            "name": "",
+            "number": -1
+          }
+        };
+
+        deepEqual(deepAttributes(emp), empAttributes);
+        // test various types, and make sure they don't do anything weird
+        deepEqual(deepAttributes({"a": "b", "c": "d"}), {"a": "b", "c": "d"});
+        deepEqual(deepAttributes([1, 2, 3]), [1, 2, 3]);
+        deepEqual(deepAttributes(1), 1);
+        deepEqual(deepAttributes("foo"), "foo");
+        deepEqual(deepAttributes(true), true);
+        deepEqual(deepAttributes(null), null);
+    });
+
     module("Examples", {
         setup:function () {
 


### PR DESCRIPTION
It's sometimes helpful to be able to retrieve the attributes of a model and its related models as a simple Javascript object. This utility function does that. Note that this is different from the `toJSON` function: that can (and should) be customized, while `Backbone.Association.deepAttributes` specifically targets `model.attributes`, which should be read-only and not customizable. **NOTE**: this probably blows up on cyclic graphs, but it's good enough for my purposes.

I also included a short unit test for the VERSION attribute, since that lives on the same object, and was missing a test.
