### PR TITLE
Provide the relation itself to relatedModel function handlers.

### DIFF
--- a/backbone-associations.js
+++ b/backbone-associations.js
@@ -146,7 +146,7 @@
 
                     // Call function if relatedModel is implemented as a function
                     if (relatedModel && !(relatedModel.prototype instanceof BackboneModel))
-                        relatedModel = _.isFunction(relatedModel) ? relatedModel.call(this, attributes) : relatedModel;
+                        relatedModel = _.isFunction(relatedModel) ? relatedModel.call(this, attributes, relation) : relatedModel;
 
                     // Get class if relation and map is stored as a string.
                     if (relatedModel && _.isString(relatedModel)) {

--- a/test/associated-model.js
+++ b/test/associated-model.js
@@ -906,7 +906,7 @@ $(document).ready(function () {
         equal(djob.get('organizable') instanceof Models.Department, true);
 
     });
-    
+
 
     test("Fetch collection with reset: Issue#45", 5, function () {
         var Product = Backbone.AssociatedModel.extend({

--- a/test/associated-model.js
+++ b/test/associated-model.js
@@ -875,15 +875,19 @@ $(document).ready(function () {
         f.at(0).get('xxx').add({name:"n2"}); //Fire add:xxx
     });
 
-    test("Polymorphic Associate : Issue#23", 2, function () {
+    test("Polymorphic Associate : Issue#23", 3, function () {
 
-        var Models = {};
+        var Models = {},
+            relation;
+
         Models.Job = Backbone.AssociatedModel.extend({
             relations:[
                 {
                     type:Backbone.One,
                     key:'organizable',
-                    relatedModel:function (attributes) {
+                    relatedModel:function (attributes, _relation) {
+                        relation = _relation;
+
                         return Models[attributes['organizable_type'] || this.get('organizable_type')];
                     }
                 }
@@ -902,6 +906,8 @@ $(document).ready(function () {
 
         equal(cjob.get('organizable') instanceof Models.Company, true);
         equal(djob.get('organizable') instanceof Models.Department, true);
+
+        equal(relation, Models.Job.prototype.relations[0]);
 
     });
 

--- a/test/associated-model.js
+++ b/test/associated-model.js
@@ -875,21 +875,19 @@ $(document).ready(function () {
         f.at(0).get('xxx').add({name:"n2"}); //Fire add:xxx
     });
 
-    test("Polymorphic Associate : Issue#23", 3, function () {
+    test("Polymorphic Associate : Issue#23", 2, function () {
 
         var Models = {},
-            relation;
+            findRelatedType = (function (attributes, relation) {
+                return Models[attributes[relation.key + '_type'] || this.get(relation.key + '_type')];
+            });
 
         Models.Job = Backbone.AssociatedModel.extend({
             relations:[
                 {
                     type:Backbone.One,
                     key:'organizable',
-                    relatedModel:function (attributes, _relation) {
-                        relation = _relation;
-
-                        return Models[attributes['organizable_type'] || this.get('organizable_type')];
-                    }
+                    relatedModel: findRelatedType
                 }
             ]
 
@@ -907,10 +905,8 @@ $(document).ready(function () {
         equal(cjob.get('organizable') instanceof Models.Company, true);
         equal(djob.get('organizable') instanceof Models.Department, true);
 
-        equal(relation, Models.Job.prototype.relations[0]);
-
     });
-
+    
 
     test("Fetch collection with reset: Issue#45", 5, function () {
         var Product = Backbone.AssociatedModel.extend({

--- a/test/associated-model.js
+++ b/test/associated-model.js
@@ -879,7 +879,8 @@ $(document).ready(function () {
 
         var Models = {},
             findRelatedType = (function (attributes, relation) {
-                return Models[attributes[relation.key + '_type'] || this.get(relation.key + '_type')];
+                var key = relation.key + '_type';
+                return Models[attributes[key] || this.get(key)];
             });
 
         Models.Job = Backbone.AssociatedModel.extend({


### PR DESCRIPTION
For one example of where this is useful, please see:

https://gist.github.com/monokrome/5954751

This happens in any case where a function is abstracted out and the relation data can not be assumed, so I would think that it would be a fairly common issue.
