### PR TITLE
Add remoteKey for json serializing relations to different key name.

### DIFF
--- a/backbone-associations.js
+++ b/backbone-associations.js
@@ -456,10 +456,13 @@
                 // and added it's json representation to parents' json representation.
                 if (this.relations) {
                     _.each(this.relations, function (relation) {
-                        var attr = this.attributes[relation.key];
+                        var dest_attr,
+                            key = relation.key,
+                            attr = this.attributes[key];
                         if (attr) {
                             aJson = attr.toJSON(options);
-                            json[relation.key] = _.isArray(aJson) ? _.compact(aJson) : aJson;
+                            dest_attr = relation.remoteKey || key;
+                            json[dest_attr] = _.isArray(aJson) ? _.compact(aJson) : aJson;
                         }
                     }, this);
                 }


### PR DESCRIPTION
During our migration from Backbone Relational, we were only missing one feature: setting a different key/property name for a related model during toJSON(). A popular use case for this is when using Ruby on Rails with nested attributes. Often the server is expecting related models to be scoped under `keyname_attributes` while the client side related model might only be scoped under `keyname`.

Attached is a tiny fix which is similar to `keyDestination` in Backbone Relational, however, in this commit, the keyname is `remoteKey` as I feel this is more explicit.

All tests currently pass, but I have yet to add one for this feature due to time and the fact that I'm not too familiar with qunit.

What do you think?
