### PR TITLE
Improve _bubbleEvent performance

### DIFF
--- a/backbone-associations.js
+++ b/backbone-associations.js
@@ -316,25 +316,31 @@
                 var pathTokens = getPathArray(eventPath),
                     initialTokens = _.initial(pathTokens), colModel;
 
-                colModel = relationValue.find(function (model) {
-                    if (eventObject === model) return true;
-                    if (!model) return false;
-                    var changedModel = model.get(initialTokens);
+                if (eventObject.id) {
+                  var gottenModel = relationValue.get(eventObject.id);
+                  if (eventObject === gottenModel) colModel = gottenModel;
+                }
+                if (!colModel) {
+                  colModel = relationValue.find(function (model) {
+                      if (eventObject === model) return true;
+                      if (!model) return false;
+                      var changedModel = model.get(initialTokens);
 
-                    if ((changedModel instanceof AssociatedModel || changedModel instanceof BackboneCollection)
-                        && eventObject === changedModel)
-                        return true;
+                      if ((changedModel instanceof AssociatedModel || changedModel instanceof BackboneCollection)
+                          && eventObject === changedModel)
+                          return true;
 
-                    changedModel = model.get(pathTokens);
+                      changedModel = model.get(pathTokens);
 
-                    if ((changedModel instanceof AssociatedModel || changedModel instanceof BackboneCollection)
-                        && eventObject === changedModel)
-                        return true;
+                      if ((changedModel instanceof AssociatedModel || changedModel instanceof BackboneCollection)
+                          && eventObject === changedModel)
+                          return true;
 
-                    if (changedModel instanceof BackboneCollection && colObject
-                        && colObject === changedModel)
-                        return true;
-                });
+                      if (changedModel instanceof BackboneCollection && colObject
+                          && colObject === changedModel)
+                          return true;
+                  });
+                }
                 colModel && (indexEventObject = relationValue.indexOf(colModel));
             }
 


### PR DESCRIPTION
In many cases eventObject is a Backbone Model
This means we can do a faster lookup using Collection.get instead of
Collection.find
