### PR TITLE
No need to call toJSON if not serializing

### DIFF
--- a/backbone-associations.js
+++ b/backbone-associations.js
@@ -452,15 +452,15 @@
                             attr = this.attributes[key],
                             serialize = !relation.isTransient;
 
-                        aJson = attr && attr.toJSON ? attr.toJSON(options) : attr;
-
                         // Remove default Backbone serialization for associations.
                         delete json[key];
 
                         //Assign to remoteKey if specified. Otherwise use the default key.
                         //Only for non-transient relationships
-                        if (serialize)
+                        if (serialize) {
+                            aJson = attr && attr.toJSON ? attr.toJSON(options) : attr;
                             json[remoteKey || key] = _.isArray(aJson) ? _.compact(aJson) : aJson;
+                        }
 
                     }, this);
                 }


### PR DESCRIPTION
Minor tweak...

I noticed that the code was calling `attr.toJSON` then ignoring the result if not serializing.  so moved the `toJSON` call into the `if (serialize)` branch.
