### PR TITLE
prevent infinite recursion that can arise from closed loop of forward & reverse relations

### DIFF
--- a/backbone-associations.js
+++ b/backbone-associations.js
@@ -247,12 +247,14 @@
                             //Is the passed in data for the same key?
                             if (currVal && data.attributes[idKey] &&
                                 currVal.attributes[idKey] === data.attributes[idKey]) {
-                                // Setting this flag will prevent events from firing immediately. That way clients
-                                // will not get events until the entire object graph is updated.
-                                currVal._deferEvents = true;
-                                // Perform the traditional `set` operation
-                                currVal._set(val instanceof AssociatedModel ? val.attributes : val, relationOptions);
-                                data = currVal;
+                                if (currVal != data) {
+                                    // Setting this flag will prevent events from firing immediately. That way clients
+                                    // will not get events until the entire object graph is updated.
+                                    currVal._deferEvents = true;
+                                    // Perform the traditional `set` operation
+                                    currVal._set(val instanceof AssociatedModel ? val.attributes : val, relationOptions);
+                                    data = currVal;
+                                }
                             } else {
                                 newCtx = true;
                             }


### PR DESCRIPTION
In my investigations into using reverse relations in my app (see #88) , I was getting infinite recursion on `set` of my object graph.  Added a check to make sure that the relation-spawned recursive `set` doesn't happen if the value is already there.

I haven't isolated a sample case nor added a test for this, but figured I'd send the PR first.  (In case it'd be obvious to you how to create a case that would trigger this.)
