### PR TITLE
Added reverseKey support for Many relations

### DIFF
--- a/backbone-associations.js
+++ b/backbone-associations.js
@@ -246,13 +246,16 @@
 
                             data = val instanceof AssociatedModel ? val : new relatedModel(val, relationOptions);
                             //Is the passed in data for the same key?
-                            if (currVal && data.attributes[idKey] &&
+                            if (currVal && data.attributes[idKey] != null &&
                                 currVal.attributes[idKey] === data.attributes[idKey]) {
-                                // Setting this flag will prevent events from firing immediately. That way clients
-                                // will not get events until the entire object graph is updated.
-                                currVal._deferEvents = true;
-                                // Perform the traditional `set` operation
-                                currVal._set(val instanceof AssociatedModel ? val.attributes : val, relationOptions);
+
+                                if (currVal !== val) {
+                                    // Setting this flag will prevent events from firing immediately. That way clients
+                                    // will not get events until the entire object graph is updated.
+                                    currVal._deferEvents = true;
+                                    // Perform the traditional `set` operation
+                                    currVal._set(val instanceof AssociatedModel ? val.attributes : val, relationOptions);
+                                }
                                 data = currVal;
                             } else {
                                 newCtx = true;

--- a/backbone-associations.js
+++ b/backbone-associations.js
@@ -272,7 +272,7 @@
                                 }
                             }
 
-                        } else if (relation.type === Backbone.One) {
+                        } else if (relation.type === Backbone.One || relation.type == Backbone._ManyReverse) {
 
                             if (!relatedModel)
                                 throw new Error('specify a relatedModel for Backbone.One type');
@@ -292,17 +292,11 @@
                                 data = currVal;
                             } else {
                                 newCtx = true;
+                                if (relation.type === Backbone._ManyReverse) {
+                                    this._updateReverseRelation(relation, data);
+                                    bubbleOK = false; // Suppress circular triggers of the form change:parent.children[0].parent...
+                                }
                             }
-
-                        } else if (relation.type === Backbone._ManyReverse) {
-
-                            if (currVal != val) {
-                                this._updateReverseRelation(relation, val);
-                            }
-
-                            data = val;
-                            bubbleOK = false; // Suppress circular triggers of the form change:parent.children[0].parent...
-
                         } else {
                             throw new Error('type attribute must be specified and have the values Backbone.One or Backbone.Many');
                         }

--- a/backbone-associations.js
+++ b/backbone-associations.js
@@ -78,6 +78,7 @@
     Backbone.Associations.Many = Backbone.Many = "Many";
     Backbone.Associations.One = Backbone.One = "One";
     Backbone.Associations.Self = Backbone.Self = "Self";
+    Backbone.Associations._ManyReverse = Backbone._ManyReverse = "_ManyReverse";
     // Set default separator
     Backbone.Associations.SEPARATOR = ".";
     Backbone.Associations.getSeparator = getSeparator;
@@ -98,6 +99,15 @@
         // and prevent redundant event to be triggered in case of cyclic model graphs.
         _proxyCalls:undefined,
 
+        // When constructing a model, defer processing of reverse
+        // relations until initialization of the model is complete, 
+        // to ensure that relation events are not triggered when the model isn't in a well-defined state.
+        constructor:function () {
+            this._deferReverseRelations = true;
+            var result = AssociatedModel.__super__.constructor.apply(this, arguments);
+            this._processPendingReverseRelations();
+            return result;
+        },
 
         // Get the value of an attribute.
         get:function (attr) {
@@ -179,7 +189,9 @@
                         map = relation.map,
                         currVal = this.attributes[relationKey],
                         idKey = currVal && currVal.idAttribute,
-                        val, relationOptions, data, relationValue, newCtx = false;
+                        val, relationOptions, data, relationValue, newCtx = false,
+                        reverseKey = relation.reverseKey, reverseRelation,
+                        bubbleOK = Backbone.Associations.EVENTS_BUBBLE;
 
                     // Call function if relatedModel is implemented as a function
                     if (relatedModel && !(relatedModel.prototype instanceof BackboneModel))
@@ -213,6 +225,26 @@
                                 throw new Error('collectionType must inherit from Backbone.Collection');
                             }
 
+                            if (reverseKey) {
+                                var relatedProto = relatedModel.prototype;
+                                reverseRelation = {
+                                    type: Backbone._ManyReverse,
+                                    relatedModel: this.constructor,
+                                    key: reverseKey,
+                                    reverseOf: relation,
+                                }
+                                if (!relatedModel) {
+                                    throw new Error('must specify a relatedModel if specifying reverseKey');
+                                }
+                                if (!_.findWhere(relatedProto.relations || [], reverseRelation)) {
+                                    relatedProto.relations || (relatedProto.relations = []);
+                                    if (_.findWhere(relatedProto.relations, {key: reverseKey})) {
+                                        throw new Error('reverseKey "'+reverseKey+'" is the same as an existing key');
+                                    }
+                                    relatedProto.relations.push(reverseRelation);
+                                }
+                            }
+
                             if (currVal) {
                                 // Setting this flag will prevent events from firing immediately. That way clients
                                 // will not get events until the entire object graph is updated.
@@ -229,8 +261,13 @@
 
                                 if (val instanceof BackboneCollection) {
                                     data = val;
+                                    data._reverseRelation = reverseRelation;
+                                    data._reverseModel = this;
                                 } else {
                                     data = collectionType ? new collectionType() : this._createCollection(relatedModel);
+                                    data._reverseRelation = reverseRelation;
+                                    data._reverseModel = this;
+                                    data._deferEvents = true;
                                     data[relationOptions.reset ? 'reset' : 'set'](val, relationOptions);
                                 }
                             }
@@ -257,6 +294,15 @@
                                 newCtx = true;
                             }
 
+                        } else if (relation.type === Backbone._ManyReverse) {
+
+                            if (currVal != val) {
+                                this._updateReverseRelation(relation, val);
+                            }
+
+                            data = val;
+                            bubbleOK = false; // Suppress circular triggers of the form change:parent.children[0].parent...
+
                         } else {
                             throw new Error('type attribute must be specified and have the values Backbone.One or Backbone.Many');
                         }
@@ -269,7 +315,7 @@
                         // Only add callback if not defined or new Ctx has been identified.
                         if (newCtx || (relationValue && !relationValue._proxyCallback)) {
                             relationValue._proxyCallback = function () {
-                                return Backbone.Associations.EVENTS_BUBBLE &&
+                                return bubbleOK &&
                                     this._bubbleEvent.call(this, relationKey, relationValue, arguments);
                             };
                             relationValue.on("all", relationValue._proxyCallback, this);
@@ -278,9 +324,14 @@
                     }
                     //Distinguish between the value of undefined versus a set no-op
                     if (attributes.hasOwnProperty(relationKey)) {
-                        //Maintain reverse pointers - a.k.a parents
                         var updated = attributes[relationKey];
                         var original = this.attributes[relationKey];
+
+                        if (relation.type == Backbone._ManyReverse && !updated) {
+                            this._updateReverseRelation(relation, undefined);
+                        }
+
+                        //Maintain reverse pointers - a.k.a parents
                         if (updated) {
                             updated.parents = updated.parents || [];
                             (_.indexOf(updated.parents, this) == -1) && updated.parents.push(this);
@@ -306,7 +357,8 @@
                 _proxyCalls = relationValue._proxyCalls,
                 cargs,
                 eventPath = opt[1],
-                basecolEventPath;
+                basecolEventPath,
+                orphanIndex = this._orphanIndex || {};
 
 
             //Short circuit the listen in to the nested-graph event
@@ -317,7 +369,7 @@
             // Find the specific object in the collection which has changed.
             var source = sources.pop() || eventObject;
             if (relationValue instanceof BackboneCollection && isDefaultEvent) {
-                indexEventObject = relationValue.indexOf(source);
+                indexEventObject = orphanIndex[source.cid] || relationValue.indexOf(source);
                 sources.push(relationValue.parents[0]);
             } else {
                 sources.push(relationValue);
@@ -399,6 +451,149 @@
             return collection;
         },
 
+        // Called when a model updates a reverse key of a Many relation;
+        // removes/adds from appropriate collections.
+        _updateReverseRelation:function(relation, newValue) {
+            if (this._deferReverseRelations) {
+                this._deferReverseRelation("_updateReverseRelation", arguments);
+                return;
+            }
+            this._deferEvents = true;
+            this._reverseSetPending = true;
+
+            var oldValue = this.attributes[relation.key];
+            var collection;
+            if (oldValue && oldValue != newValue && (collection = oldValue.attributes[relation.reverseOf.key])) {
+                collection._deferEvents = true;
+                if (!this._reverseRemovePending) {
+                    this._newReverseModel = newValue;
+                    collection.remove(this);
+                }
+                this._addAssociatedEventSources(collection);
+            }
+            if (newValue && (collection = newValue.attributes[relation.reverseOf.key])) {
+                collection._deferEvents = true;
+                collection.add(this);
+            }
+            delete this._reverseSetPending;
+        },
+
+        // Called when models are removed from a Many relation; sets their
+        // their reverseKeys to null (unless the model is in the midst of
+        // a setting the reverse key to something else).
+        _propagateReverseRemove:function (relation, models, method, options) {
+            if (this._deferReverseRelations) {
+                this._deferReverseRelation("_propagateReverseRemove", arguments);
+                return;
+            }
+
+            var reverseKey = relation.reverseKey;
+            var collection = this.attributes[relation.key];
+            var silent = (options || {}).silent;
+            var attrs = {}
+
+            attrs[reverseKey] = null;
+
+            _.each(models, function(model) {
+                this._orphanIndex || (this._orphanIndex = {})
+                this._orphanIndex[model.cid] = collection.indexOf(model);
+                if (!model._reverseSetPending) {
+                    model._deferEvents = true;
+                    model._reverseRemovePending = true;
+                    model._setAttr(attrs);
+                    delete model._reverseRemovePending;
+                }
+                // trigger explicitly, since by the time
+                // pending events will get processed, the model
+                // will no longer be in this collection
+                if (method === "remove" && !silent) {
+                    collection.trigger(method, model, collection, options);
+                    collection.trigger("change", model, options);
+                    collection.trigger("change:"+reverseKey, model, model._newReverseModel, options);
+                }
+            }, this);
+
+            collection._addAssociatedEventSources(models);
+        },
+
+        // Called when models are removed from a Many relation; sets their
+        // their reverseKeys to the new value.
+        _propagateReverseAdd:function (relation, models) {
+            if (this._deferReverseRelations) {
+                this._deferReverseRelation("_propagateReverseAdd", arguments);
+                return;
+            }
+            var reverseKey = relation.reverseKey;
+            var attrs = {}
+            attrs[reverseKey] = this;
+            _.each(models, function(model) {
+                if (!model._reverseSetPending && model.attributes[reverseKey] != this) {
+                    model._deferEvents = true;
+                    model._setAttr(attrs);
+                }
+            }, this);
+            this.attributes[relation.key]._addAssociatedEventSources(models);
+        },
+
+        _deferReverseRelation: function(method, args) {
+            this._pendingReverseRelations || (this._pendingReverseRelations = []);
+            this._pendingReverseRelations.push({method: method, arguments: args});
+        },
+
+        _processPendingReverseRelations:function () {
+            delete this._deferReverseRelations;
+            if (this._pendingReverseRelations) {
+                this._deferEvents = true;
+                _.each(this._pendingReverseRelations, function(r) {
+                    this[r.method].apply(this, r.arguments);
+                }, this);
+                delete this._pendingReverseRelations;
+                this._processPendingEvents();
+            }
+        },
+
+        // Add more sources of pending events that will need to be
+        // processed. This is for sources whose relationship has been
+        // severed (i.e. model no longer member of collection) and so
+        // wouldn't be found when traversing relationships when processing
+        // the deferred events.
+        _addAssociatedEventSources:function (sources) {
+            this._associatedEventSources || (this._associatedEventSources = []);
+            this._associatedEventSources = this._associatedEventSources.concat(sources);
+        },
+
+        // Call this when intercepting a (non-deferred) "destroy" event, in
+        // order to disconnect reverse relations silently to avoid sending
+        // "change" events.
+        _processDestroyEvent:function (eventArguments) {
+            _.each(this.relations || [], function(relation) {
+                if (relation.type == Backbone._ManyReverse) {
+                    this._deferEvents = true;
+                    var reverseKey = relation.key,
+                        reverseModel = this.attributes[reverseKey],
+                        attrs = {};
+                    if (reverseModel) {
+                        var collection = reverseModel.attributes[relation.reverseOf.key];
+                        collection._deferEvents = true;
+
+                        // disconnect reverse relation, silently to avoid
+                        // change events
+                        this.attributes[reverseKey] = null;
+                        collection.remove(this, {silent: true});
+
+                        // manually trigger "remove" and "destroy" events
+                        this.trigger("remove", this, collection);
+                        collection.trigger("remove destroy", this, collection);
+
+                        this._addAssociatedEventSources(collection);
+                    }
+                }
+            }, this);
+            this._deferEvents = false;
+            ModelProto.trigger.apply(this, eventArguments);
+            this._processPendingEvents();
+        },
+
         // Process all pending events after the entire object graph has been updated
         _processPendingEvents:function () {
             if (!this._processedEvents) {
@@ -419,6 +614,12 @@
                     val && val._processPendingEvents();
                 }, this);
 
+                _.each(this._associatedEventSources, function(model) {
+                    model._processPendingEvents();
+                }, this);
+                this._associatedEventSources = [];
+
+                delete this._orphanIndex;
                 delete this._processedEvents;
             }
         },
@@ -430,6 +631,8 @@
                 this._pendingEvents = this._pendingEvents || [];
                 // Maintain a queue of pending events to trigger after the entire object graph is updated.
                 this._pendingEvents.push({c:this, a:arguments});
+            } else if (name == "destroy") {
+                this._processDestroyEvent(arguments);
             } else {
                 ModelProto.trigger.apply(this, arguments);
             }
@@ -546,12 +749,47 @@
         proxies[method] = BackboneCollection.prototype[method];
 
         CollectionProto[method] = function (models, options) {
+            var reverseRelation = this._reverseRelation;
+            var reverseModel = this._reverseModel;
+            var topLevel;
+
             //Short-circuit if this collection doesn't hold `AssociatedModels`
             if (this.model.prototype instanceof AssociatedModel && this.parents) {
                 //Find a map function if available and perform a transformation
                 arguments[0] = map2models(this.parents, this, models);
             }
-            return proxies[method].apply(this, arguments);
+
+            if (reverseRelation) {
+                var models = [].concat(arguments[0]);
+                topLevel = !this._deferEvents;
+                this._deferEvents = true;
+                _.each(models, function(model) { model._deferEvents = true; });
+                var orphans, silent = (options || {}).silent;
+                switch (method) {
+                    case 'remove':
+                        orphans = models;
+                        break;
+                    case 'reset':
+                        orphans = _.difference(this.models, models);
+                        break;
+                };
+                if (orphans) {
+                    reverseModel._propagateReverseRemove(reverseRelation.reverseOf, orphans, method, options);
+                }
+            }
+
+            var result = proxies[method].apply(this, arguments);
+
+            if (reverseRelation) {
+                if (method != 'remove') {
+                    reverseModel._propagateReverseAdd(reverseRelation.reverseOf, [].concat(result));
+                }
+                if (topLevel) {
+                    this._processPendingEvents();
+                }
+            }
+
+            return result;
         }
     });
 
@@ -569,6 +807,7 @@
 
     // Attach process pending event functionality on collections as well. Re-use from `AssociatedModel`
     CollectionProto._processPendingEvents = AssociatedModel.prototype._processPendingEvents;
+    CollectionProto._addAssociatedEventSources = AssociatedModel.prototype._addAssociatedEventSources;
 
 
 }).call(this);

--- a/backbone-associations.js
+++ b/backbone-associations.js
@@ -543,7 +543,7 @@
                     this._newReverseModel = newValue;
                     collection.remove(this);
                 }
-                this._addAssociatedEventSources(collection, true);
+                this._addAssociatedEventSources(collection);
             }
             if (newValue && (collection = newValue.attributes[reverseKey])) {
                 if (!(collection instanceof BackboneCollection)) {
@@ -594,7 +594,7 @@
                 }
             }, this);
 
-            collection._addAssociatedEventSources(models, true);
+            collection._addAssociatedEventSources(models);
         },
 
         // Called when models are added to a Many relation; sets their
@@ -613,7 +613,7 @@
                     model._setAttr(attrs);
                 }
             }, this);
-            collection._addAssociatedEventSources(models, true);
+            collection._addAssociatedEventSources(models);
         },
 
         _deferReverseRelation: function(method, args) {
@@ -638,8 +638,7 @@
         // severed (i.e. model no longer member of collection) and so
         // wouldn't be found when traversing relationships when processing
         // the deferred events.
-        _addAssociatedEventSources:function (sources, really) {
-            if (!really) return;
+        _addAssociatedEventSources:function (sources) {
             this._associatedEventSources || (this._associatedEventSources = []);
             this._associatedEventSources = this._associatedEventSources.concat(sources);
         },
@@ -666,7 +665,7 @@
                         this.trigger("remove", this, collection);
                         collection.trigger("remove destroy", this, collection);
 
-                        this._addAssociatedEventSources(collection, true);
+                        this._addAssociatedEventSources(collection);
                     }
                 }
             }, this);

--- a/backbone-associations.js
+++ b/backbone-associations.js
@@ -207,6 +207,8 @@
                         // Map `val` if a transformation function is provided.
                         val = map ? map.call(this, val, collectionType ? collectionType : relatedModel) : val;
 
+                        if (val == currVal) return;
+
                         // If `relation.type` is `Backbone.Many`,
                         // Create `Backbone.Collection` with passed data and perform Backbone `set`.
                         if (relation.type === Backbone.Many) {
@@ -245,17 +247,16 @@
                         } else if (relation.type === Backbone.One) {
 
                             data = val instanceof AssociatedModel ? val : new relatedModel(val, relationOptions);
+
                             //Is the passed in data for the same key?
                             if (currVal && data.attributes[idKey] != null &&
                                 currVal.attributes[idKey] === data.attributes[idKey]) {
 
-                                if (currVal !== val) {
-                                    // Setting this flag will prevent events from firing immediately. That way clients
-                                    // will not get events until the entire object graph is updated.
-                                    currVal._deferEvents = true;
-                                    // Perform the traditional `set` operation
-                                    currVal._set(val instanceof AssociatedModel ? val.attributes : val, relationOptions);
-                                }
+                                // Setting this flag will prevent events from firing immediately. That way clients
+                                // will not get events until the entire object graph is updated.
+                                currVal._deferEvents = true;
+                                // Perform the traditional `set` operation
+                                currVal._set(val instanceof AssociatedModel ? val.attributes : val, relationOptions);
                                 data = currVal;
                             } else {
                                 newCtx = true;

--- a/test/associated-model.js
+++ b/test/associated-model.js
@@ -1283,6 +1283,15 @@ $(document).ready(function () {
         deepEqual(allEvents, expectedEvents, "trigger the expected events");
     });
 
+    test("reverse relation set mother silent", 3, function() {
+
+        son1.set('mother', mother1, { silent: true });
+        equal(mother0.sonNames(), "son0", "mother0 sons");
+        equal(mother1.sonNames(), "son1", "mother1 sons");
+
+        deepEqual(allEvents, expectedEvents, "trigger the expected events");
+    });
+
     test("reverse relation set mother no-op", 1, function () {
         // potential inifinite recursion: setting son0's mother to mother0
         // could cause it to re-add to mother0's sons collection, which
@@ -1381,6 +1390,15 @@ $(document).ready(function () {
             "nested-change"
         ];
         expectedEvents.teacherStudents = ["change", "change:mother"];
+
+        deepEqual(allEvents, expectedEvents, "trigger the expected events");
+    });
+
+    test("reverse relation set sons silent", 3, function () {
+
+        mother1.set("sons", [son1], {silent: true});
+        equal(mother0.sonNames(), "son0", "mother0 sons");
+        equal(mother1.sonNames(), "son1", "mother1 sons");
 
         deepEqual(allEvents, expectedEvents, "trigger the expected events");
     });

--- a/test/associated-model.js
+++ b/test/associated-model.js
@@ -1128,6 +1128,32 @@ $(document).ready(function () {
         deepEqual(allEvents, expectedEvents, "trigger the expected events");
     });
 
+    test("reverse relation construct parent in child", 3, function() {
+        var newSon = new Son({
+            name: "newSon",
+            mother: {
+                name: "newMother"
+            }
+        });
+        var mother = newSon.get('mother');
+        ok(mother instanceof Mother, "created an instance of Mother");
+        equal(mother.get('name'), "newMother");
+        equal(mother.get('sons[0].name'), "newSon");
+    });
+
+    test("reverse relation construct child in parent", 3, function() {
+        var newMother = new Mother({
+            name: "newMother",
+            sons: [{
+                name: "newSon"
+            }]
+        });
+        var son = newMother.get('sons[0]');
+        ok(son instanceof Son, "created an instance of Son");
+        equal(son.get('name'), "newSon");
+        equal(son.get('mother.name'), "newMother");
+    });
+
 
     test("reverse relation set mother", 37, function() {
         son1.on("change:mother",                assert_son1_in_mother1);

--- a/test/associated-model.js
+++ b/test/associated-model.js
@@ -339,24 +339,18 @@ $(document).ready(function () {
             });
             allEvents= {
                 mother0: [],
-                mother0Sons: [],
                 mother1: [],
-                mother1Sons: [],
                 son0: [],
                 son1: [],
                 teacher: [],
-                teacherStudents: []
             };
             expectedEvents = JSON.parse(JSON.stringify(allEvents));
             var addEvent = function(source, args) { allEvents[source].push(args[0]) ; allEvents[source].sort() };
             mother0.on("all", function() { addEvent("mother0", arguments); });
-            mother0.get('sons').on("all", function() { addEvent("mother0Sons", arguments); });
             mother1.on("all", function() { addEvent("mother1", arguments); });
-            mother1.get('sons').on("all", function() { addEvent("mother1Sons", arguments); });
             son0.on("all", function() { addEvent("son0", arguments); });
             son1.on("all", function() { addEvent("son1", arguments); });
             teacher.on("all", function() { addEvent("teacher", arguments); });
-            teacher.get('students').on("all", function() { addEvent("teacherStudents", arguments); });
         }
     });
 
@@ -1195,9 +1189,7 @@ $(document).ready(function () {
         });
 
         expectedEvents.mother1 =         ["add:sons"];
-        expectedEvents.mother1Sons =     ["add"];
         expectedEvents.teacher =         ["add:students"];
-        expectedEvents.teacherStudents = ["add"];
 
         deepEqual(allEvents, expectedEvents, "trigger the expected events");
     });
@@ -1230,7 +1222,6 @@ $(document).ready(function () {
             "nested-change",
             "remove:sons"
         ];
-        expectedEvents.mother0Sons =     ["change", "change:mother", "remove"];
         expectedEvents.son1 =         ["add", "change", "change:mother", "remove"];
 
         expectedEvents.teacher = [
@@ -1240,7 +1231,6 @@ $(document).ready(function () {
             "change:students[1].mother",
             "nested-change",
         ];
-        expectedEvents.teacherStudents = ["change", "change:mother"];
 
         deepEqual(allEvents, expectedEvents, "trigger the expected events");
     });
@@ -1271,6 +1261,16 @@ $(document).ready(function () {
         equal(son.get('mother.name'), "newMother");
     });
 
+    test("reverse relation bubble through", 2, function() {
+        mother0.on("change:sons[0].name", function() {
+            equal(this.get('sons[0].name'), "newSonName");
+        });
+        son0.on("change:mother.name", function() {
+            equal(this.get('mother.name'), "newMotherName");
+        });
+        son0.set("name", "newSonName");
+        mother0.set("name", "newMotherName");
+    });
 
     test("reverse relation set mother", 37, function() {
         son1.on("change:mother",                assert_son1_in_mother1);
@@ -1294,7 +1294,6 @@ $(document).ready(function () {
             "nested-change",
             "remove:sons"
         ];
-        expectedEvents.mother0Sons =    ["change", "change:mother", "remove"];
         expectedEvents.mother1 =        [
             "add:sons",
             "change:sons[*]",
@@ -1303,7 +1302,6 @@ $(document).ready(function () {
             "change:sons[0].mother",
             "nested-change",
         ];
-        expectedEvents.mother1Sons =    ["add", "change", "change:mother"];
         expectedEvents.son1 =           ["add", "change", "change:mother", "remove"];
         expectedEvents.teacher =        [
             "change:students[*]",
@@ -1312,7 +1310,6 @@ $(document).ready(function () {
             "change:students[1].mother",
             "nested-change"
         ];
-        expectedEvents.teacherStudents = ["change", "change:mother"];
 
         deepEqual(allEvents, expectedEvents, "trigger the expected events");
     });
@@ -1359,7 +1356,6 @@ $(document).ready(function () {
             "nested-change",
             "remove:sons"
         ];
-        expectedEvents.mother0Sons =    ["change", "change:mother", "remove"];
         expectedEvents.mother1 =        [
             "add:sons",
             "change:sons[*]",
@@ -1368,7 +1364,6 @@ $(document).ready(function () {
             "change:sons[0].mother",
             "nested-change",
         ];
-        expectedEvents.mother1Sons =    ["add", "change", "change:mother"];
         expectedEvents.son1 =           ["add", "change", "change:mother", "remove"];
         expectedEvents.teacher =        [
             "change:students[*]",
@@ -1377,7 +1372,6 @@ $(document).ready(function () {
             "change:students[1].mother",
             "nested-change"
         ];
-        expectedEvents.teacherStudents = ["change", "change:mother"];
 
         deepEqual(allEvents, expectedEvents, "trigger the expected events");
     });
@@ -1404,7 +1398,6 @@ $(document).ready(function () {
             "nested-change",
             "remove:sons"
         ];
-        expectedEvents.mother0Sons =    ["change", "change:mother", "remove"];
         expectedEvents.mother1 =        [
             "add:sons",
             "change:sons[*]",
@@ -1414,7 +1407,6 @@ $(document).ready(function () {
             "nested-change",
             "sort:sons",
         ];
-        expectedEvents.mother1Sons =    ["add", "change", "change:mother", "sort"];
         expectedEvents.son1 =           ["add", "change", "change:mother", "remove"];
         expectedEvents.teacher =        [
             "change:students[*]",
@@ -1423,7 +1415,6 @@ $(document).ready(function () {
             "change:students[1].mother",
             "nested-change"
         ];
-        expectedEvents.teacherStudents = ["change", "change:mother"];
 
         deepEqual(allEvents, expectedEvents, "trigger the expected events");
     });
@@ -1446,7 +1437,6 @@ $(document).ready(function () {
         mother0.set("sons", [son0, son1]);
 
         expectedEvents.mother0 =     ["sort:sons"]
-        expectedEvents.mother0Sons = ["sort"]
 
         deepEqual(allEvents, expectedEvents, "trigger the expected events");
     });
@@ -1471,11 +1461,22 @@ $(document).ready(function () {
             "change:sons[2].mother",
             "nested-change",
         ];
-        expectedEvents.mother0Sons =    ["add", "change", "change:mother"];
 
         deepEqual(allEvents, expectedEvents, "trigger the expected events");
     });
 
+    test("reverse relation create with mother", 2, function() {
+
+        var newSon = new Son({
+            name: "newSon",
+            mother: mother0,
+        });
+        equal(newSon.get('mother.name'), "mother0");
+
+        expectedEvents.mother0 = [ "add:sons" ];
+
+        deepEqual(allEvents, expectedEvents, "trigger the expected events");
+    });
     test("reverse relation unset mother", 25, function () {
         son1.on("change:mother",         assert_son1_orphan);
         mother0.on("remove:sons",        assert_son1_orphan);
@@ -1494,7 +1495,6 @@ $(document).ready(function () {
             "change:sons[1].mother",
             "remove:sons"
         ];
-        expectedEvents.mother0Sons =    ["change", "change:mother", "remove"];
         expectedEvents.son1 =           ["change", "change:mother", "remove"];
         expectedEvents.teacher =        [
             "change:students[*]",
@@ -1503,7 +1503,6 @@ $(document).ready(function () {
             "change:students[1].mother",
             "nested-change"
         ];
-        expectedEvents.teacherStudents = ["change", "change:mother"];
 
         deepEqual(allEvents, expectedEvents, "trigger the expected events");
     });
@@ -1526,7 +1525,6 @@ $(document).ready(function () {
             "change:sons[1].mother",
             "remove:sons"
         ];
-        expectedEvents.mother0Sons =    ["change", "change:mother", "remove"];
         expectedEvents.son1 =           ["change", "change:mother", "remove"];
         expectedEvents.teacher =        [
             "change:students[*]",
@@ -1535,7 +1533,6 @@ $(document).ready(function () {
             "change:students[1].mother",
             "nested-change"
         ];
-        expectedEvents.teacherStudents = ["change", "change:mother"];
 
         deepEqual(allEvents, expectedEvents, "trigger the expected events");
     });
@@ -1550,11 +1547,9 @@ $(document).ready(function () {
 
         mother0.get("sons").reset([son0]);
 
-        expectedEvents.mother0Sons =    ["reset"];
         expectedEvents.mother0 =        [
             "reset:sons"
         ];
-        expectedEvents.mother0Sons =    ["reset"];
         expectedEvents.son1 =           ["change", "change:mother"];
         expectedEvents.teacher =        [
             "change:students[*]",
@@ -1563,7 +1558,6 @@ $(document).ready(function () {
             "change:students[1].mother",
             "nested-change"
         ];
-        expectedEvents.teacherStudents = ["change", "change:mother"];
 
         deepEqual(allEvents, expectedEvents, "trigger the expected events");
     });
@@ -1584,13 +1578,11 @@ $(document).ready(function () {
             "destroy:sons",
             "remove:sons"
         ];
-        expectedEvents.mother0Sons =    ["destroy", "remove"];
         expectedEvents.son1 =           ["destroy", "remove", "remove"];
         expectedEvents.teacher =        [
             "destroy:students",
             "remove:students",
         ];
-        expectedEvents.teacherStudents = ["destroy", "remove"];
 
         deepEqual(allEvents, expectedEvents, "trigger the expected events");
     });

--- a/test/associated-model.js
+++ b/test/associated-model.js
@@ -348,7 +348,7 @@ $(document).ready(function () {
                 teacherStudents: []
             };
             expectedEvents = JSON.parse(JSON.stringify(allEvents));
-            addEvent = function(source, args) { allEvents[source].push(args[0]) ; allEvents[source].sort() };
+            var addEvent = function(source, args) { allEvents[source].push(args[0]) ; allEvents[source].sort() };
             mother0.on("all", function() { addEvent("mother0", arguments); });
             mother0.get('sons').on("all", function() { addEvent("mother0Sons", arguments); });
             mother1.on("all", function() { addEvent("mother1", arguments); });

--- a/test/associated-model.js
+++ b/test/associated-model.js
@@ -1283,6 +1283,17 @@ $(document).ready(function () {
         deepEqual(allEvents, expectedEvents, "trigger the expected events");
     });
 
+    test("reverse relation set mother no-op", 1, function () {
+        // potential inifinite recursion: setting son0's mother to mother0
+        // could cause it to re-add to mother0's sons collection, which
+        // could re-set son0's mother to mother0.
+        mother0.set("id", 0, { silent: true});
+
+        son0.set("mother", mother0);
+
+        deepEqual(allEvents, expectedEvents, "trigger the expected events");
+    });
+
     test("reverse relation add son", 37, function () {
         son1.on("change:mother",                assert_son1_in_mother1);
         mother0.on("remove:sons",               assert_son1_in_mother1);
@@ -1370,6 +1381,20 @@ $(document).ready(function () {
             "nested-change"
         ];
         expectedEvents.teacherStudents = ["change", "change:mother"];
+
+        deepEqual(allEvents, expectedEvents, "trigger the expected events");
+    });
+
+    test("reverse relation set sons no-op", 1, function () {
+
+        // potential inifinite recursion: setting mother0's
+        // sons could cause son0 to set its mother to mother0, which will
+        // 'merge' its attributes and attempt to set sons to [son0, son1] again.
+        mother0.set("id", 0, { silent: true});
+        mother0.set("sons", [son0, son1]);
+
+        expectedEvents.mother0 =     ["sort:sons"]
+        expectedEvents.mother0Sons = ["sort"]
 
         deepEqual(allEvents, expectedEvents, "trigger the expected events");
     });

--- a/test/associated-model.js
+++ b/test/associated-model.js
@@ -1050,6 +1050,89 @@ $(document).ready(function () {
         throws(function() { new Experience(); }, /teacher/);
     });
 
+    window.TestAssociatedCircular = {}
+
+    test("reverse relation defined on child", function() {
+        var Zoo = TestAssociatedCircular.Zoo = Backbone.AssociatedModel.extend({
+            defaults: {
+                name:"",
+                animals: []
+            }
+        });
+        var Animal = TestAssociatedCircular.Animal = Backbone.AssociatedModel.extend({
+            relations: [{
+                type: Backbone.One,
+                key: "zoo",
+                relatedModel: "TestAssociatedCircular.Zoo",
+                reverseKey: "animals"
+            }],
+            defaults: {
+                name: ""
+            }
+        });
+        var zoo = new Zoo({name: "zoo"});
+        var animal = new Animal({name: "animal"});
+        animal.set('zoo', zoo);
+        equal(zoo.get('animals[0].name'), "animal");
+    });
+
+    test("reverse relation defined in both directions", function() {
+        var Zoo = TestAssociatedCircular.Zoo = Backbone.AssociatedModel.extend({
+            relations: [{
+                type: Backbone.Many,
+                key: "animals",
+                relatedModel: "TestAssociatedCircular.Animal",
+                reverseKey: "zoo"
+            }],
+            defaults: {
+                name:"",
+                animals: []
+            }
+        });
+        var Animal = TestAssociatedCircular.Animal = Backbone.AssociatedModel.extend({
+            relations: [{
+                type: Backbone.One,
+                key: "zoo",
+                relatedModel: "TestAssociatedCircular.Zoo",
+                reverseKey: "animals"
+            }],
+            defaults: {
+                name: ""
+            }
+        });
+        var zoo = new Zoo({name: "zoo"});
+        var animal = new Animal({name: "animal"});
+        animal.set('zoo', zoo);
+        equal(zoo.get('animals[0].name'), "animal");
+    });
+
+    test("reverse relation defined inconsistently", function() {
+        var Zoo = TestAssociatedCircular.Zoo = Backbone.AssociatedModel.extend({
+            relations: [{
+                type: Backbone.Many,
+                key: "animals",
+                relatedModel: "TestAssociatedCircular.Animal",
+                reverseKey: "zoo"
+            }],
+            defaults: {
+                name:"",
+                animals: []
+            }
+        });
+        var Animal = TestAssociatedCircular.Animal = Backbone.AssociatedModel.extend({
+            relations: [{
+                type: Backbone.One,
+                key: "livesIn",
+                relatedModel: "TestAssociatedCircular.Zoo",
+                reverseKey: "animals"
+            }],
+            defaults: {
+                name: ""
+            }
+        });
+        throws(function() { new Zoo(); }, /Inconsistent/);
+    });
+
     test("reverse relation model construction", 29, function() {
 
         // reverse relations should not be added until after construction (including

--- a/test/associated-model.js
+++ b/test/associated-model.js
@@ -980,6 +980,40 @@ $(document).ready(function () {
         emp.get('works_for').get("locations").at(0).set('zip', 94403, {dummy:true});
     });
 
+    test("relation resolution caching", 4, function() {
+        ok(_.all(emp.relations, function(relation) { return relation._isResolved;}), "Employee relations cached");
+        ok(_.all(mother0.relations, function(relation) { return relation._isResolved;}), "Mother relations cached");
+        ok(_.all(son0.relations, function(relation) { return relation._isResolved;}), "Son relations cached");
+
+        var Club = Backbone.AssociatedModel.extend({
+            relations:[{
+                type:Backbone.Many,
+                key:'members',
+                relatedModel:function (relation, attributes) {
+                    return function (attrs, options) {
+                        if (_.isArray(attrs.dependents)) {
+                            return new Employee(attrs);
+                        }
+
+                        return new Dependent(attrs);
+                    }
+                }
+            }],
+            defaults:{
+                name:"",
+                members:[]
+            },
+        });
+
+        var club = new Club({
+            name:"Club X"
+        });
+
+        ok(_.all(club.relations, function(relation) { return !relation._isResolved;}), "polymorphic relations not cached");
+    });
+
+
+
     //
     // reverse relation assertions that test for atomicity: on any event
     // callback, all relations should be in place
@@ -3611,4 +3645,5 @@ $(document).ready(function () {
         emp.get("dependents").remove([child1]);
         emp.get("dependents").reset();
     });
+
 });


### PR DESCRIPTION
Hi.  Well, since I mouthed off in #51 about how much I wanted reverse keys, I figured I should put my money where my mouth is.   So I've taken the liberty of coding up an implementation of reverseKey (for Many relations only).

Here are some notes/documentation.  For the sake of discussion, assume a relation of the form

```
Zoo = Backbone.AssociatedModel.extend({
                 relations: [{
                      type: Backbone.Many,
                      key: 'animals,
                      relatedModel: Animal,
                      reverseKey: 'zoo'
                 }],
                 defaults: {
                      children: []
                 }
             });
```
- You can add an Animal to a Zoo's  "animals" collection from either direction:
  
  ```
  animal.set("zoo", zoo)
  zoo.get("animals").add(animal)  // or set(animal) or reset([animal])
  ```
- You can likewise remove an Animal from a Zoo's "animals" collection from either direction:
  
  ```
  animal.set("zoo", null)
  animal.set("zoo", otherZoo) // removes from current zoo and adds to otherZoo
  zoo.get("animals").remove(animal) // or reset([otherAnimal]) which implicitly removes animal
  animal.destroy()
  ```
- No events are sent until the object graph is completely updated.  Here's a quick rundown of the events:
  - When an Animal is added to a Zoo, in addition to the "add" event, the new zoo's "animals" collection gets a "change" and a "change:zoo" event noting that the animal's "zoo" attribute has been set, with the change-related API working properly, and the events properly bubbling to the zoo model.
  - When an Animal is removed from a Zoo, in addition to the "remove" event, the new zoo's "animals" collection gets a "change" and a "change:zoo" event noting that the animal's "zoo" attribute has been set, with the change-related API working properly, and the events properly bubbling to the zoo model.  (Note at the time the change event is triggered, the animal is no longer in the collection; in the zoo's event path for the change event, the index refers to the index prior to removal).
  - The only exception when adding is that if an Animal is created with a zoo provided as an initialization attribute, that zoo's "animals" collection gets an "add" event but no "change" events (it's not considered a change since that's the initial zoo value).
  - The only exception when deleting is that if an Animal is destroyed, it's zoo's "animals" collection gets a "remove" event but no "change" events (it's not considered a change, since that's the final zoo value).
  - When creating a new Animal model with a zoo provided as an initialization attribute, or when creating a new Zoo model with a set of models as an initialization attribute, the relations are not processed until after initialization of the new model.  This ensures that the new model has been completely initialized before the related objects start handling it.  (One quirk: within the new model's initializer, the new model's own attributes will have been set, but the related objects will not have been updated.  That's arguably something that should be changed, so that the related objects _will_ have been updated, although no events triggered yet.)

(Getting the events right was the trickiest part of the implementation!)  

I've included a whole bunch of tests for the new behavior, and have verified that all the old tests still pass.  I tried to minimize/localize the impact on the code, and of course to have minimal runtime impact if relationKey is not specified.  I've tried it out in my app and it seems to be working well.  Hope you like it!

And of course I'm open to suggestions If you think I did anything wrong in terms of functionality or implementation.

Happy new year :)
