### PR TITLE
Removing references from parents

### DIFF
--- a/backbone-associations.js
+++ b/backbone-associations.js
@@ -369,7 +369,8 @@
                         if (updated) {
                             updated.parents = updated.parents || [];
                             (_.indexOf(updated.parents, this) == -1) && updated.parents.push(this);
-                        } else if (original && original.parents.length > 0) { // New value is undefined
+                        }
+                        if (original && original.parents.length > 0 && original != updated) {
                             original.parents = _.difference(original.parents, [this]);
                             // Don't bubble to this parent anymore
                             original._proxyCallback && original.off("all", original._proxyCallback, this);


### PR DESCRIPTION
``` javascript
var Foo = Backbone.AssociatedModel.extend({});

var Bar = Backbone.AssociatedModel.extend({
       relations: [{
       type: Backbone.One,
            key: 'rel',
            relatedModel: Foo
       }]
});
```

Create some instances:

``` javascript
var foo1 = new Foo;
var foo2 = new Foo;

var bar = new Bar({rel: foo1});
```

Now foo1.parents contains one element (bar).
Next, change rel attribute:

``` javascript
bar.set({rel: foo2})
```

Conceptually, bar must retire from foo1.parents, but it is'nt.

```
foo1.parents.length => 1
foo2.parents.length => 1
```
