### PR TITLE
Check existence, not value of identity for 1-1 relations

### DIFF
--- a/backbone-associations.js
+++ b/backbone-associations.js
@@ -330,7 +330,7 @@
 
                             data = val instanceof AssociatedModel ? val : new relatedModel(val, relationOptions);
                             //Is the passed in data for the same key?
-                            if (currVal && data.attributes[idKey] &&
+                            if (currVal && data.attributes.hasOwnProperty(idKey) &&
                                 currVal.attributes[idKey] === data.attributes[idKey]) {
                                 // Setting this flag will prevent events from firing immediately. That way clients
                                 // will not get events until the entire object graph is updated.

--- a/test/associated-model.js
+++ b/test/associated-model.js
@@ -2920,6 +2920,26 @@ $(document).ready(function () {
         node1.set({parent:node3, children:[node2, node3]});
     });
 
+    test("Backbone.One with child having falsy id", 1, function () {
+	var Child = Backbone.AssociatedModel.extend({
+	});
+
+	var Parent = Backbone.AssociatedModel.extend({
+	    relations: [
+		{
+		    type: Backbone.One,
+		    key: "child",
+		    relatedModel: Child
+		}
+	    ]
+	});
+	var parent = new Parent();
+	parent.set({child: {id: 0}});
+	var originalCid = parent.get('child').cid;
+	parent.set({child: {id: 0}});
+	ok(originalCid == parent.get('child').cid);
+    });
+
     test("set,trigger", 13, function () {
         node1.on("change:parent", function () {
             node1.trigger("nestedevent", arguments);


### PR DESCRIPTION
In relations with type Backbone.One, _setAttr was checking that data's id
has a truthy value before comparing the identity with currVal's. This
means that if id's value is falsy, such as 0, the predicate fails even if
the actual values were the same. By checking for the id's existence
instead, we match things up correctly even with falsy identities.
