### PR TITLE
Removing references from parents when using destroy [optional]

### DIFF
--- a/test/associated-model.js
+++ b/test/associated-model.js
@@ -1730,6 +1730,60 @@ $(document).ready(function () {
         equal(foo1.parents.length == 0, true);
         equal(foo2.parents.length == 1, true);
     });
+    
+    test('Issue #113', 8, function() {
+
+        var Foo = Backbone.AssociatedModel.extend({});
+
+        var Bar = Backbone.AssociatedModel.extend({
+            relations: [
+                {
+                    type: Backbone.One,
+                    key: 'rel',
+                    relatedModel: Foo
+                }
+            ],
+            url: 'fc'
+        });
+
+        var foo = new Foo;
+
+        var bar1 = new Bar({rel: foo});
+
+        equal(foo.parents.length == 1, true);
+
+        bar1.destroy();
+
+        equal(foo.parents.length == 0, true);
+
+        bar1 = new Bar({rel: foo});
+        var bar2 = new Bar({rel: foo});
+
+        equal(foo.parents.length == 2, true);
+
+        bar2.destroy();
+
+        equal(foo.parents.length == 1, true);
+
+        bar1.destroy({remove_references: false});
+
+        equal(foo.parents.length == 1, true);
+
+        var foo = new Foo;
+
+        bar1 = new Bar({rel: foo});
+        bar2 = new Bar({rel: foo});
+
+        equal(foo.parents.length == 2, true);
+
+        bar1.destroy({wait: true});
+
+        equal(foo.parents.length == 1, true);
+
+        bar2.destroy({wait: true, remove_references: false});
+
+        equal(foo.parents.length == 1, true);
+    });
 
     test("transform from store", 16, function () {
         emp.set('works_for', 99);


### PR DESCRIPTION
``` javascript
var Foo = Backbone.AssociatedModel.extend({});

var Bar = Backbone.AssociatedModel.extend({
       relations: [{
       type: Backbone.One,
            key: 'rel',
            relatedModel: Foo
       }]
});
```

Create some instances:

``` javascript
var foo = new Foo;

var bar = new Bar({rel: foo1});
```

Now foo.parents contains one element (bar).
Next, destroy bar.

``` javascript
bar.destroy()
// foo.parents.length => 1
```

As you can see, after the removal of foo, parents.length not changed. This is normal, since foo can be used later.

``` javascript
bar.save({rel: foo})
```

But there are cases when bar is no longer used and bar must be removed from foo.parents.

This PR helps to solve this problem.

``` javascript
bar.destroy({remove_references: true}) // default true
// foo.parents.length => 0
```
