### PR TITLE
_proxyCallback can't be off

### DIFF
--- a/backbone-associations.js
+++ b/backbone-associations.js
@@ -316,10 +316,12 @@
                         // Add proxy events to respective parents.
                         // Only add callback if not defined or new Ctx has been identified.
                         if (newCtx || (relationValue && !relationValue._proxyCallback)) {
-                            relationValue._proxyCallback = function () {
-                                return Backbone.Associations.EVENTS_BUBBLE &&
-                                    this._bubbleEvent.call(this, relationKey, relationValue, arguments);
-                            };
+                            if(!relationValue._proxyCallback) {
+                            	relationValue._proxyCallback = function () {
+                                	return Backbone.Associations.EVENTS_BUBBLE &&
+                                    	this._bubbleEvent.call(this, relationKey, relationValue, arguments);
+                            	};
+                            }
                             relationValue.on("all", relationValue._proxyCallback, this);
                         }
 

--- a/test/associated-model.js
+++ b/test/associated-model.js
@@ -1785,6 +1785,31 @@ $(document).ready(function () {
         equal(foo.parents.length == 1, true);
     });
 
+    test('Issue #115', 2, function() {
+        var Foo = Backbone.AssociatedModel.extend({});
+
+        var Bar = Backbone.AssociatedModel.extend({
+            relations: [
+                {
+                    type: Backbone.One,
+                    key: 'rel',
+                    relatedModel: Foo
+                }
+            ],
+        });
+
+        var foo = new Foo;
+
+        var bar1 = new Bar({rel: foo});
+        var bar2 = new Bar({rel: foo})
+
+        equal(foo._events.all.length, 2);
+
+        bar1.destroy();
+
+        equal(foo._events.all.length, 1);
+    });
+
     test("transform from store", 16, function () {
         emp.set('works_for', 99);
         ok(emp.get('works_for').get('name') == "sales", "Mapped id to dept instance");


### PR DESCRIPTION
``` javascript
var Foo = Backbone.AssociatedModel.extend({});

        var Bar = Backbone.AssociatedModel.extend({
            relations: [
                {
                    type: Backbone.One,
                    key: 'rel',
                    relatedModel: Foo
                }
            ],
        });

        var foo = new Foo;

        var bar1 = new Bar({rel: foo});
        var bar2 = new Bar({rel: foo})

        // foo.parents.length => 2
        // foo._events.all.length => 2 (proxyCallback's for calling bubbleEvent)
        bar1.destroy();

        // foo.parents.length => 1
        // foo._events.all.length => 2 // bug
```
