### PR TITLE
cleanup method don't unbind _proxyCallback from a relationValue

### DIFF
--- a/backbone-associations.js
+++ b/backbone-associations.js
@@ -618,7 +618,10 @@
         cleanup:function () {
             _.each(this.relations, function (relation) {
                 var val = this.attributes[relation.key];
-                val && (val.parents = _.difference(val.parents, [this]));
+                if(val) {
+                    val._proxyCallback && val.off("all", val._proxyCallback, this);
+                    val.parents = _.difference(val.parents, [this]);
+                }
             }, this);
             this.off();
         },

--- a/test/associated-model.js
+++ b/test/associated-model.js
@@ -1810,6 +1810,33 @@ $(document).ready(function () {
         equal(foo._events.all.length, 1);
     });
 
+    test('Issue #117', 4, function() {
+        var Foo = Backbone.AssociatedModel.extend({});
+
+        var Bar = Backbone.AssociatedModel.extend({
+            relations: [
+                {
+                    type: Backbone.One,
+                    key: 'rel',
+                    relatedModel: Foo
+                }
+            ],
+        });
+
+        var foo = new Foo;
+
+        var bar1 = new Bar({rel: foo});
+        var bar2 = new Bar({rel: foo});
+
+        equal(foo.parents.length, 2);
+        equal(foo._events.all.length, 2);
+
+        bar2.cleanup();
+
+        equal(foo.parents.length, 1);
+        equal(foo._events.all.length, 1);
+    });
+
     test("transform from store", 16, function () {
         emp.set('works_for', 99);
         ok(emp.get('works_for').get('name') == "sales", "Mapped id to dept instance");

--- a/test/associated-model.js
+++ b/test/associated-model.js
@@ -1832,6 +1832,7 @@ $(document).ready(function () {
         equal(foo._events.all.length, 2);
 
         bar2.cleanup();
+        bar2 = undefined;
 
         equal(foo.parents.length, 1);
         equal(foo._events.all.length, 1);


### PR DESCRIPTION
``` javascript
var Foo = Backbone.AssociatedModel.extend({});

var Bar = Backbone.AssociatedModel.extend({
            relations: [
                {
                    type: Backbone.One,
                    key: 'rel',
                    relatedModel: Foo
                }
            ],
});

var foo = new Foo;

var bar1 = new Bar({rel: foo});
var bar2 = new Bar({rel: foo});

bar2.cleanup()
// foo.parents.length => 1
// foo._events.all.length => 2 (_proxyCallback don't retired)
```
