### PR TITLE
Wrong model serialization

### DIFF
--- a/backbone-associations.js
+++ b/backbone-associations.js
@@ -615,7 +615,8 @@
                             remoteKey = relation.remoteKey,
                             attr = this.attributes[key],
                             serialize = !relation.isTransient,
-                            serialize_keys = relation.serialize || []
+                            serialize_keys = relation.serialize || [],
+                            _options = _.clone(options);
 
                         // Remove default Backbone serialization for associations.
                         delete json[key];
@@ -626,12 +627,12 @@
 
                             // Pass the keys to serialize as options to the toJSON method.
                             if (serialize_keys.length) {
-                                options ?
-                                    (options.serialize_keys = serialize_keys) :
-                                    (options = {serialize_keys: serialize_keys})
+                                _options ?
+                                    (_options.serialize_keys = serialize_keys) :
+                                    (_options = {serialize_keys: serialize_keys})
                             }
 
-                            aJson = attr && attr.toJSON ? attr.toJSON(options) : attr;
+                            aJson = attr && attr.toJSON ? attr.toJSON(_options) : attr;
                             json[remoteKey || key] = _.isArray(aJson) ? _.compact(aJson) : aJson;
                         }
 

--- a/test/associated-model.js
+++ b/test/associated-model.js
@@ -1971,6 +1971,39 @@ $(document).ready(function () {
         equal(foo._events.all.length, 1);
     });
 
+    test('Issue #1177', 2, function() {
+        var Foo = Backbone.AssociatedModel.extend({});
+        var Bar = Backbone.AssociatedModel.extend({});
+
+        var Baz = Backbone.AssociatedModel.extend({
+            relations: [
+                {
+                    type: Backbone.One,
+                    key: 'fooRel',
+                    relatedModel: Foo,
+                    serialize: ['name']
+                },
+                {
+                    type: Backbone.One,
+                    key: 'barRel',
+                    relatedModel: Bar,
+                }
+            ],
+        });
+
+        var foo = new Foo({name: 'John', age: 30});
+        var bar = new Bar({test: 1});
+
+        var baz = new Baz({'fooRel': foo, 'barRel': bar});
+
+        var json = baz.toJSON();
+
+        console.log(json);
+
+        deepEqual(json.fooRel, {name: 'John'});
+        deepEqual(json.barRel, {test: 1});
+    });
+
     test("transform from store", 16, function () {
         emp.set('works_for', 99);
         ok(emp.get('works_for').get('name') == "sales", "Mapped id to dept instance");


### PR DESCRIPTION
``` javascript
var Foo = Backbone.AssociatedModel.extend({});
var Bar = Backbone.AssociatedModel.extend({});

var Baz = Backbone.AssociatedModel.extend({
            relations: [
                {
                    type: Backbone.One,
                    key: 'fooRel',
                    relatedModel: Foo,
                    serialize: ['name']
                },
                {
                    type: Backbone.One,
                    key: 'barRel',
                    relatedModel: Bar,
                }
            ],
});

var foo = new Foo({name: 'John', age: 30});
var bar = new Bar({test: 1});

var baz = new Baz({'fooRel': foo, 'barRel': bar});

var json = baz.toJSON();
// => {fooRel: {name: 'John'}, barRel: {}} //bug.
```

Should be as follows: `{fooRel: {name: 'Jonh'}, barRel: {test: 1}}`
This occurs due to overwriting `options`.
