### PR TITLE
Fixes exeption if `map` return null or undefined

### DIFF
--- a/backbone-associations.js
+++ b/backbone-associations.js
@@ -276,6 +276,10 @@
 
                         // Map `val` if a transformation function is provided.
                         val = map ? map.call(this, val, collectionType ? collectionType : relatedModel) : val;
+                        if(!val) {
+                            attributes[relationKey] = val;
+                            return;
+                        }
 
                         // If `relation.type` is `Backbone.Many`,
                         // Create `Backbone.Collection` with passed data and perform Backbone `set`.

--- a/test/associated-model.js
+++ b/test/associated-model.js
@@ -2004,6 +2004,26 @@ $(document).ready(function () {
         deepEqual(json.barRel, {test: 1});
     });
 
+    test('map return null', 1, function() {
+    	var Foo = Backbone.AssociatedModel.extend({});
+
+        var Bar = Backbone.AssociatedModel.extend({
+            relations: [
+                {
+                    type: Backbone.One,
+                    key: 'rel',
+                    relatedModel: Foo,
+                    map: function(m) {
+                    	return null;
+                    }
+                }
+            ],
+        });
+
+        var bar = new Bar({rel: {'test': ''}});
+        equal(bar.get('rel'), null);
+    });
+
     test("transform from store", 16, function () {
         emp.set('works_for', 99);
         ok(emp.get('works_for').get('name') == "sales", "Mapped id to dept instance");


### PR DESCRIPTION
``` javascript
var Foo = Backbone.AssociatedModel.extend({});

        var Bar = Backbone.AssociatedModel.extend({
            relations: [
                {
                    type: Backbone.One,
                    key: 'rel',
                    relatedModel: Foo,
                    map: function(m) {
                        if(m.rel.test == '') return null;
                        return m;
                    }
                }
            ],
        });

        var bar = new Bar({rel: {'test': ''}});
```

this code raised exeption:

```
Uncaught TypeError: Cannot call method 'hasOwnProperty' of null backbone-associations.js:314
(anonymous function) backbone-associations.js:314
_.each._.forEach underscore.js:79
Backbone.AssociatedModel.Backbone.Associations.AssociatedModel.BackboneModel.extend._setAttr backbone-associations.js:259
Backbone.AssociatedModel.Backbone.Associations.AssociatedModel.BackboneModel.extend._set backbone-associations.js:233
Backbone.AssociatedModel.Backbone.Associations.AssociatedModel.BackboneModel.extend.set backbone-associations.js:197
Backbone.Model backbone-min.js:266
Backbone.AssociatedModel.Backbone.Associations.AssociatedModel.BackboneModel.extend.constructor backbone-associations.js:115
Backbone.AssociatedModel.extend._.extend.constructor notified-model.js:7
child backbone-min.js:1583
_.extend._prepareModel backbone-min.js:929
_.extend.set backbone-min.js:720
_.each.CollectionProto.(anonymous function) backbone-associations.js:795
_.extend.add backbone-min.js:652
_.extend.reset backbone-min.js:783
_.each.CollectionProto.(anonymous function) backbone-associations.js:795
_.extend.fetch.options.success backbone-min.js:879
x.Callbacks.c jquery-1.10.1.min.js:745
x.Callbacks.p.fireWith jquery-1.10.1.min.js:779
k jquery-1.10.1.min.js:1872
x.ajaxTransport.send.r
```
