### PR TITLE
Check if val is null/undefined in get()

### DIFF
--- a/backbone-associations.js
+++ b/backbone-associations.js
@@ -178,8 +178,8 @@
         get:function (attr) {
             var cache = this.__attributes__,
                 val = ModelProto.get.call(this, attr),
-                obj = cache ? val || cache[attr] : val;
-            return obj ? obj : this._getAttr.apply(this, arguments);
+                obj = cache ? ((val != null) ? val : cache[attr]) : val;
+            return (obj != null) ? obj : this._getAttr.apply(this, arguments);
         },
 
         // Set a hash of model attributes on the Backbone Model.


### PR DESCRIPTION
Not actually sure how the cache is working - but this is my best guess at how to check for null/undefined, to preserve '0' values returned from the ModelProto.get.call()
